### PR TITLE
Fix build for polars 0.54: replace removed ListChunked into_iter

### DIFF
--- a/polars-rows-iter/src/iter_from_column/iter_from_column_series.rs
+++ b/polars-rows-iter/src/iter_from_column/iter_from_column_series.rs
@@ -33,8 +33,13 @@ impl<'a> IterFromColumn<'a> for Option<Series> {
 
 pub(crate) fn create_series_iter<'a>(column: &'a Column) -> PolarsResult<impl Iterator<Item = Option<Series>> + 'a> {
     let column_name = column.name().as_str();
-    let iter: Box<dyn Iterator<Item = Option<Series>>> = match column.dtype() {
-        DataType::List(_) => Box::new(column.list()?.into_iter()),
+    let iter: Box<dyn Iterator<Item = Option<Series>> + 'a> = match column.dtype() {
+        DataType::List(_) => Box::new(
+            column
+                .list()?
+                .amortized_iter()
+                .map(|opt| opt.map(|series| series.deep_clone())),
+        ),
         dtype => {
             return Err(
                 polars_err!(SchemaMismatch: "Cannot get Series from column '{column_name}' with dtype: {dtype}"),
@@ -64,8 +69,18 @@ mod tests {
         let col = create_column("col", &dtype, false, height, &mut rng);
         let col_opt = create_column("col_opt", &dtype, true, height, &mut rng);
 
-        let col_values = col.list().unwrap().into_iter().map(|v| v.unwrap()).collect_vec();
-        let col_opt_values = col_opt.list().unwrap().into_iter().collect_vec();
+        let col_values = col
+            .list()
+            .unwrap()
+            .amortized_iter()
+            .map(|v| v.unwrap().deep_clone())
+            .collect_vec();
+        let col_opt_values = col_opt
+            .list()
+            .unwrap()
+            .amortized_iter()
+            .map(|v| v.map(|series| series.deep_clone()))
+            .collect_vec();
 
         let df = DataFrame::new(height, vec![col, col_opt]).unwrap();
 
@@ -96,7 +111,12 @@ mod tests {
         let col = create_column("col", &dtype, false, height, &mut rng);
         let col_opt = create_column("col_opt", &dtype, true, height, &mut rng);
 
-        let col_values = col.list().unwrap().into_iter().map(|v| v.unwrap()).collect_vec();
+        let col_values = col
+            .list()
+            .unwrap()
+            .amortized_iter()
+            .map(|v| v.unwrap().deep_clone())
+            .collect_vec();
 
         let df = DataFrame::new(height, vec![col, col_opt]).unwrap();
 
@@ -118,7 +138,12 @@ mod tests {
         let col = create_column("col", &dtype, false, height, &mut rng);
         let col_opt = create_column("col_opt", &dtype, true, height, &mut rng);
 
-        let col_opt_values = col_opt.list().unwrap().into_iter().collect_vec();
+        let col_opt_values = col_opt
+            .list()
+            .unwrap()
+            .amortized_iter()
+            .map(|v| v.map(|series| series.deep_clone()))
+            .collect_vec();
 
         let df = DataFrame::new(height, vec![col, col_opt]).unwrap();
 


### PR DESCRIPTION
## Summary

polars 0.54 removed the `IntoIterator` impl for `&ListChunked`, so `.into_iter()` on a list column no longer compiles. This broke `create_series_iter` and the series unit tests.

This PR switches to the supported `amortized_iter()` API and converts each yielded `AmortSeries` into an independent owned `Series` via `deep_clone()`.

## Why `deep_clone()` and not a plain clone

`amortized_iter()` reuses a single `Series` container and swaps its inner array pointer on every step to avoid reallocating. A shallow clone would still alias that mutating container and get overwritten as iteration advances. `deep_clone()` snapshots the current chunk into a fresh container, breaking the aliasing.

Note this is *not* a data copy: `deep_clone()` only allocates a new `Series` container and bumps the Arrow buffer's atomic refcount (`SharedStorage`), so the list element data is shared, not duplicated — O(1) per row.

## Test plan

- `cargo build` — clean
- `cargo test --workspace` — all pass, including `series_rows_iter_test`, `series_scalar_iter_test`, `series_scalar_iter_opt_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)